### PR TITLE
Performance improvement - don't fetch time entries one by one

### DIFF
--- a/src/main/java/UnemployedVoodooFamily/Logic/Session.java
+++ b/src/main/java/UnemployedVoodooFamily/Logic/Session.java
@@ -124,7 +124,7 @@ public class Session {
             if(fetchedEntries.size() > 999) {
 
                 // fetch from new start date
-                OffsetDateTime newStart = timeEntries.get(fetchedEntries.size() - 1).getStart();
+                OffsetDateTime newStart = fetchedEntries.get(fetchedEntries.size() - 1).getStart();
                 fetchedEntries = jToggl.getTimeEntries(newStart, end);
 
                 //remove eventual duplicate time entry


### PR DESCRIPTION
There was a performance issue - the while loop in Session:getchTimeEntries() got only a single new entry every time, therefore the loop was called thousands of times. 
This fix makes sure that time offset for the next request is the last entry in the previous fetch (not the first entry).