### PR TITLE
Use version number variable for auto-update of .jar and .exe file names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>TogglTimeSheet</groupId>
     <artifactId>TogglTimeSheet</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -72,10 +72,9 @@
                         <goals><goal>launch4j</goal></goals>
                         <configuration>
                             <headerType>gui</headerType>
-                            <outfile>target/TogglTimeSheet-1.0.1.exe</outfile>
+                            <outfile>target/TogglTimeSheet-${version}.exe</outfile>
                             <icon>src/main/resources/icons/app_icon/logo.ico</icon>
-                            <!-- !!!!!!   Update this when version changes  !!!!!-->
-                            <jar>target/TogglTimeSheet-1.0.1.jar</jar>
+                            <jar>target/TogglTimeSheet-${version}.jar</jar>
                             <errTitle>TogglTimeSheet</errTitle>
                             <classPath>
                                 <mainClass>UnemployedVoodooFamily.Main</mainClass>


### PR DESCRIPTION
Use version number variable for auto-update of .jar and .exe file names.
Update version nr to 1.0.2